### PR TITLE
Improve Stream chat notifications and context lifecycle

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router';
-import { useStreamChat } from '../context/StreamChatContext'; // Import du contexte custom
+import useStreamChat from '../context/useStreamChat'; // Import du contexte custom
 import useAuthUser from '../hooks/useAuthUser';
 import useLogout from '../hooks/useLogout';
 import { useNotifications } from '../hooks/useNotifications';

--- a/frontend/src/context/StreamChatContext.js
+++ b/frontend/src/context/StreamChatContext.js
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+
+const StreamChatContext = createContext(null);
+
+export default StreamChatContext;
+

--- a/frontend/src/context/useStreamChat.js
+++ b/frontend/src/context/useStreamChat.js
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+import StreamChatContext from "./StreamChatContext.js";
+
+/**
+ * Hook pour accéder au client Stream partout dans l'app
+ */
+const useStreamChat = () => {
+        const context = useContext(StreamChatContext);
+        if (!context) {
+                throw new Error("useStreamChat doit être utilisé dans StreamChatProvider");
+        }
+        return context;
+};
+
+export default useStreamChat;
+

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -8,62 +8,73 @@ import { getFriendRequests } from "../lib/api";
  * @returns {Object} { totalCount, friendRequestsCount, unreadMessagesCount }
  */
 export const useNotifications = (streamClient) => {
-	const [unreadMessagesCount, setUnreadMessagesCount] = useState(0);
+        const [unreadMessagesCount, setUnreadMessagesCount] = useState(0);
 
-	// Récupération des demandes d'amis via React Query
-	const { data: friendRequests } = useQuery({
-		queryKey: ["friendRequests"],
-		queryFn: getFriendRequests,
-		refetchInterval: 30000, // Rafraîchit toutes les 30 secondes
-	});
+        // Récupération des demandes d'amis via React Query
+        const { data: friendRequests } = useQuery({
+                queryKey: ["friendRequests"],
+                queryFn: getFriendRequests,
+                refetchInterval: 30000, // Rafraîchit toutes les 30 secondes
+        });
 
-	const friendRequestsCount = friendRequests?.incomingReqs?.length || 0;
+        const friendRequestsCount = friendRequests?.incomingReqs?.length || 0;
 
-	// Écoute des messages non lus Stream en temps réel
-	useEffect(() => {
-		if (!streamClient) return;
+        // Écoute des messages non lus Stream en temps réel
+        useEffect(() => {
+                const userId = streamClient?.userID;
+                if (!streamClient || !userId) return undefined;
 
-		const updateUnreadCount = async () => {
-			try {
-				// Récupère tous les channels de l'utilisateur
-				const channels = await streamClient.queryChannels(
-					{ members: { $in: [streamClient.userID] } },
-					{},
-					{ state: true, watch: true }
-				);
+                let isActive = true;
 
-				// Calcule le total des messages non lus
-				const total = channels.reduce((sum, channel) => {
-					return sum + (channel.state.unreadCount || 0);
-				}, 0);
+                const updateUnreadCount = async () => {
+                        try {
+                                // Récupère tous les channels de l'utilisateur
+                                const channels = await streamClient.queryChannels(
+                                        { members: { $in: [userId] } },
+                                        {},
+                                        { state: true, watch: true }
+                                );
 
-				setUnreadMessagesCount(total);
-			} catch (error) {
-				console.error("Erreur récupération messages non lus:", error);
-			}
-		};
+                                // Calcule le total des messages non lus
+                                const total = channels.reduce((sum, channel) => {
+                                        const unreadForUser =
+                                                channel?.state?.read?.[userId]?.unread_messages || 0;
 
-		// Mise à jour initiale
-		updateUnreadCount();
+                                        return sum + unreadForUser;
+                                }, 0);
 
-		// Écoute des événements Stream en temps réel
-		const handleNewMessage = () => updateUnreadCount();
-		const handleMessageRead = () => updateUnreadCount();
+                                if (isActive) {
+                                        setUnreadMessagesCount(total);
+                                }
+                        } catch (error) {
+                                console.error("Erreur récupération messages non lus:", error);
+                        }
+                };
 
-		streamClient.on("message.new", handleNewMessage);
-		streamClient.on("message.read", handleMessageRead);
+                // Mise à jour initiale
+                updateUnreadCount();
 
-		// Cleanup des listeners
-		return () => {
-			streamClient.off("message.new", handleNewMessage);
-			streamClient.off("message.read", handleMessageRead);
-		};
-	}, [streamClient]);
+                // Écoute des événements Stream en temps réel
+                const handleNewMessage = () => updateUnreadCount();
+                const handleMessageRead = () => updateUnreadCount();
 
-	return {
-		totalCount: friendRequestsCount + unreadMessagesCount,
-		friendRequestsCount,
-		unreadMessagesCount,
-	};
+                streamClient.on("message.new", handleNewMessage);
+                streamClient.on("message.read", handleMessageRead);
+                streamClient.on("notification.mark_read", handleMessageRead);
+
+                // Cleanup des listeners
+                return () => {
+                        isActive = false;
+                        streamClient.off("message.new", handleNewMessage);
+                        streamClient.off("message.read", handleMessageRead);
+                        streamClient.off("notification.mark_read", handleMessageRead);
+                };
+        }, [streamClient]);
+
+        return {
+                totalCount: friendRequestsCount + unreadMessagesCount,
+                friendRequestsCount,
+                unreadMessagesCount,
+        };
 };
 export default useNotifications;

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
-import { useStreamChat } from "../context/StreamChatContext";
+import useStreamChat from "../context/useStreamChat";
 
 import {
   Channel,


### PR DESCRIPTION
## Summary
- guard unread Stream counts by user id, avoid stale state updates, and listen for read notifications to keep the badge in sync
- split the Stream chat context into a reusable hook/context pair and ensure the provider cleans up/disconnects safely
- update navbar and chat page to consume the new useStreamChat hook

## Testing
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e63339a9988320907adae4bc2da12e